### PR TITLE
Add guest endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Authorization: Bearer your-jwt-token
 | POST | /api/auth/register | Register a new user |
 | POST | /api/auth/login | Login and get authentication token |
 | POST | /organizations | Create a new organization |
-| POST | /organization/:id/events | Create a new organization event|
+| POST | /organizations/:id/events | Create a new organization event|
+| GET | /organizations/:id/events | Get organizations events|
+| GET | /guests/organizations | Get public organizations |
+| GET | /guests/organizations/:id/events | Get public organizations events|
 
 ## 1. Authentication Endpoints
 
@@ -678,4 +681,61 @@ The system uses a single-table design in DynamoDB with the following structure:
   "message": "Missing required fields: title, description, or date."
 }
 ```
+---
+
+## Guest Router
+
+### Get Public Organizations
+**Endpoint:** `GET /guests`
+
+**Description:** Retrieves a list of public organizations. The response is paginated with a maximum of 9 organizations per request.
+
+**Request Parameters:**
+- `lastEvaluatedKey` (optional, query parameter) – Used for pagination.
+
+**Response:**
+```json
+{
+  "message": "Here are all organizations!",
+  "data": {
+    "organizations": [
+      {
+        "id": "<org_id>",
+        "name": "Organization Name",
+        "description": "Public description of the organization"
+      }
+    ]
+  },
+  "lastEvaluatedKey": "<pagination_key>"
+}
+```
+
+---
+
+### Get Public Events of an Organization
+**Endpoint:** `GET /guests/organizations/:id/events`
+
+**Description:** Retrieves all public events for a specific organization.
+
+**Path Parameters:**
+- `id` (required) – Organization ID.
+
+**Response:**
+```json
+{
+  "status": "success",
+  "data": {
+    "events": [
+      {
+        "eventId": "<event_id>",
+        "name": "Event Name",
+        "date": "YYYY-MM-DD",
+        "description": "Public event description"
+      }
+    ]
+  },
+  "lastEvaluatedKey": "<pagination_key>"
+}
+```
+
 

--- a/__tests__/eventService.test.ts
+++ b/__tests__/eventService.test.ts
@@ -1,6 +1,7 @@
 import { EventService } from '../src/services/eventService';
 import { EventRepository } from '../src/repositories/eventRepository';
 import { EventRequest, Event, createEvent } from '../src/models/Event';
+import { createdEventRequest, INVALID_ORGID, invalidEvent, ORGID, validEventRequest } from './utils/eventService-test-data';
 import { v4 as uuidv4 } from 'uuid';
 
 jest.mock('../src/repositories/eventRepository');
@@ -28,66 +29,31 @@ describe('EventService', () => {
         });
 
         it('should successfully create an event', async () => {
-            const orgID = 'ORG#123';
-            const eventRequest: EventRequest = {
-                title: 'New Event',
-                description: 'Event description',
-                date: '2025-04-15',
-            };
+            mockEventRepository.createOrgEvent.mockResolvedValue(createdEventRequest);
 
-            const expectedEvent: Event = {
-                PK: 'EVENT#mock-uuid',
-                SK: 'ENTITY',
-                id: 'mock-uuid',
-                title: 'New Event',
-                description: 'Event description',
-                isPublic: true,
-                date: '2025-04-02T21:26:21.561Z',
-                createdAt: '2025-04-02T21:26:21.561Z',
-                updatedAt: '2025-04-02T21:26:21.561Z',
-                GSI2PK: orgID,
-                GSI2SK: 'EVENT#mock-uuid',
-            };
+            const result = await eventService.addEventToOrganization(ORGID, validEventRequest);
 
-            mockEventRepository.createOrgEvent.mockResolvedValue(expectedEvent);
-
-            const result = await eventService.addEventToOrganization(orgID, eventRequest);
-
-            expect(result).toEqual(expectedEvent);
-            expect(mockEventRepository.createOrgEvent).toHaveBeenCalledWith(expectedEvent);
-        });
-
-        it('should throw an error if orgID is missing', async () => {
-            await expect(
-                eventService.addEventToOrganization('', {
-                    title: 'Test',
-                    description: 'Desc',
-                    date: '2025-04-15',
-                })
-            ).rejects.toThrow('Invalid organization ID.');
+            expect(result).toEqual(createdEventRequest);
+            expect(mockEventRepository.createOrgEvent).toHaveBeenCalledWith(createdEventRequest);
         });
 
         it('should throw an error if eventRequest is invalid', async () => {
             await expect(
-                eventService.addEventToOrganization('ORG#123', {
-                    title: '',
-                    description: '',
-                    date: '',
-                })
+                eventService.addEventToOrganization(ORGID, invalidEvent)
             ).rejects.toThrow('Missing required fields: title, description, or date.');
         });
-
+        
+        it('should throw an error if eventRequest is invalid', async () => {
+            await expect(
+                eventService.addEventToOrganization(INVALID_ORGID, invalidEvent)
+            ).rejects.toThrow('Missing required fields: title, description, or date.');
+        });
+        
         it('should handle repository errors gracefully', async () => {
-            const orgID = 'ORG#123';
-            const eventRequest: EventRequest = {
-                title: 'New Event',
-                description: 'Event description',
-                date: '2025-04-15',
-            };
 
             mockEventRepository.createOrgEvent.mockRejectedValue(new Error('DynamoDB error'));
 
-            await expect(eventService.addEventToOrganization(orgID, eventRequest)).rejects.toThrow(
+            await expect(eventService.addEventToOrganization(ORGID, validEventRequest)).rejects.toThrow(
                 'Failed to create event: DynamoDB error'
             );
         });
@@ -105,53 +71,26 @@ describe('createEvent', () => {
     });
 
     it('should create an event with the correct structure and UUID', () => {
-        const orgID = 'ORG#123';
-        const eventRequest: EventRequest = {
-            title: 'New Event',
-            description: 'Event description',
-            date: '2025-04-15',
-        };
 
-        const event: Event = createEvent(orgID, eventRequest);
+        const event: Event = createEvent(ORGID, validEventRequest);
 
         // Validate UUID format and structure
-        expect(event.PK).toBe('EVENT#mock-uuid');
-        expect(event.SK).toBe('ENTITY');
-        expect(event.GSI2PK).toBe(orgID);
-        expect(event.GSI2SK).toBe('EVENT#mock-uuid');
+        expect(event.PK).toBe(createdEventRequest.PK);
+        expect(event.SK).toBe(createdEventRequest.SK);
+        expect(event.GSI2PK).toBe(createdEventRequest.GSI2PK);
+        expect(event.GSI2SK).toBe(createdEventRequest.GSI2SK);
 
         // Validate event fields
-        expect(event.title).toBe(eventRequest.title);
-        expect(event.description).toBe(eventRequest.description);
-        expect(event.isPublic).toBe(true);
+        expect(event.title).toBe(createdEventRequest.title);
+        expect(event.description).toBe(createdEventRequest.description);
+        expect(event.isPublic).toBe(createdEventRequest.isPublic);
         expect(event.date).toBeDefined();
         expect(event.createdAt).toBeDefined();
         expect(event.updatedAt).toBeDefined();
 
         // Validate that the date is correctly set to current ISO string
-        const now = new Date().toISOString();
-        expect(event.createdAt).toBe(now);
-        expect(event.updatedAt).toBe(now);
+        expect(event.createdAt).toBe(createdEventRequest.createdAt);
+        expect(event.updatedAt).toBe(createdEventRequest.updatedAt);
     });
 
-    it('should generate a unique UUID for each event', () => {
-        (uuidv4 as jest.Mock).mockReturnValueOnce('mock-uuid-1').mockReturnValueOnce('mock-uuid-2');
-
-        const orgID = 'ORG#123';
-        const eventRequest: EventRequest = {
-            title: 'Unique Event',
-            description: 'Another event description',
-            date: '2025-04-16',
-        };
-
-        const event1: Event = createEvent(orgID, eventRequest);
-        const event2: Event = createEvent(orgID, eventRequest);
-
-        // Ensure that two events created with the same input generate different UUIDs
-        expect(event1.PK).toBe('EVENT#mock-uuid-1');
-        expect(event2.PK).toBe('EVENT#mock-uuid-2');
-
-        expect(event1.GSI2SK).toBe('EVENT#mock-uuid-1');
-        expect(event2.GSI2SK).toBe('EVENT#mock-uuid-2');
-    });
 });

--- a/__tests__/orgService.test.ts
+++ b/__tests__/orgService.test.ts
@@ -13,6 +13,7 @@ import {
     existingOrgsUser,
     updateOrg,
     updatedOrganization,
+    publicOrgsArray,
 } from './utils/orgService-test-data';
 import { OrgRepository } from '../src/repositories/orgRepository';
 import { OrgService } from '../src/services/orgService';
@@ -83,6 +84,8 @@ describe(`Positive org tests`, () => {
         jest.spyOn(orgRepository, 'findOrgsByUser').mockResolvedValue(existingOrgsUser);
         jest.spyOn(orgRepository, 'updateOrgByName').mockResolvedValue(updatedOrganization);
         jest.spyOn(orgRepository, 'findSpecificOrgByUser').mockResolvedValue(createdUserAdmin);
+        jest.spyOn(orgRepository, 'findAllPublicOrgs').mockResolvedValue(publicOrgsArray);
+
         jest.spyOn(mockOrgService, 'validateUrl');
         jest.spyOn(mockOrgService, 'findSpecificOrgByUser').mockResolvedValue(createdUserAdmin);
 
@@ -135,6 +138,14 @@ describe(`Positive org tests`, () => {
         expect(orgRepository.findOrgByName).toHaveBeenCalled();
         expect(orgRepository.findSpecificOrgByUser).toHaveBeenCalled();
         expect(result).toBe(updatedOrganization);
+    });
+
+    test(`Get all public organizations`, async () => {
+        const orgServiceWithMock = new OrgService(orgRepository);
+        const result = await orgServiceWithMock.findAllPublicOrgs();
+
+        expect(orgRepository.findAllPublicOrgs).toHaveBeenCalled();
+        expect(result).toBe(publicOrgsArray);
     });
 });
 

--- a/__tests__/utils/eventService-test-data.ts
+++ b/__tests__/utils/eventService-test-data.ts
@@ -1,0 +1,47 @@
+import { title } from "process";
+import { Event, EventRequest } from "../../src/models/Event";
+
+
+export const ORGID = 'ORG#123';
+export const INVALID_ORGID = 'org##/invalid';
+
+export let validEventRequest: EventRequest= {
+    title: 'New Event',
+    description: 'Event description',
+    date: '2025-04-15',
+}
+
+export let invalidEvent: EventRequest= {
+    title: '',
+    description: '',
+    date: '',
+}
+
+export let createdEvent: Event = {
+        PK: 'EVENT#mock-uuid',
+        SK: "ENTITY",
+        id: 'mock-uuid',
+        title: 'Test Event',
+        description: 'This is a test event',
+        isPublic: true,
+        date: '2025-04-02T21:26:21.561Z',
+        createdAt: '2025-04-02T21:26:21.561Z',
+        updatedAt: '2025-04-02T21:26:21.561Z',
+        GSI2PK: 'ORG#123',
+        GSI2SK: 'EVENT#mock-uuid',
+}
+
+export let createdEventRequest: Event = {
+        PK: 'EVENT#mock-uuid',
+        SK: 'ENTITY',
+        id: 'mock-uuid',
+        title: 'New Event',
+        isPublic: true,
+        description: 'Event description',
+        date: '2025-04-02T21:26:21.561Z',
+        createdAt: '2025-04-02T21:26:21.561Z',
+        updatedAt: '2025-04-02T21:26:21.561Z',
+        GSI2PK: 'ORG#123',
+        GSI2SK: 'EVENT#mock-uuid',
+
+}

--- a/__tests__/utils/orgService-test-data.ts
+++ b/__tests__/utils/orgService-test-data.ts
@@ -43,7 +43,7 @@ export const updatedOrganization: Organization = {
     logoUrl: 'https://styleguide.culvers.com/brand-styles/logo-usage',
     website: 'https://www.culvers.com/',
     contactEmail: 'culvers@culvers.com',
-    GSI1PK: 'JOL',
+    GSI1PK: 'ORG',
     GSI1SK: 'ORG#JOLLIBEE',
 };
 
@@ -53,7 +53,7 @@ export const existingOrg: Organization = {
     GSI1SK: 'ORG#PIZZA',
     createdBy: '81dfd46b-05ba-4cd0-96d8-7ea2cb0c2c70',
     name: 'Pizza',
-    GSI1PK: 'PIZ',
+    GSI1PK: 'ORG',
     updatedAt: '2025-04-01T13:28:12.857Z',
     SK: 'ENTITY',
     isPublic: true,
@@ -76,7 +76,7 @@ export const createdOrg: Organization = {
     logoUrl: 'https://images.app.goo.gl/k7Yc6Yb6ebeaB9HB8',
     website: undefined,
     contactEmail: undefined,
-    GSI1PK: 'JOL',
+    GSI1PK: 'ORG',
     GSI1SK: 'ORG#JOLLIBEE',
 };
 
@@ -116,3 +116,40 @@ export const existingOrgsUser: UserOrganizationRelationship[] = [
         type: 'USER_ORG',
     },
 ];
+
+export const publicOrgsArray: Organization[] = [
+    {
+        PK: 'ORG#JOLLIBEE',
+        SK: 'ENTITY',
+        id: 'b58bfbd2-7055-4134-aa74-304ae42bf8a8',
+        name: 'Jollibee',
+        description: undefined,
+        createdBy: '81dfd46b-05ba-4cd0-96d8-7ea2cb0c2c70',
+        createdAt: '2025-04-01T17:26:48.302Z',
+        updatedAt: '2025-04-01T17:26:48.302Z',
+        type: 'ORGANIZATION',
+        isPublic: true,
+        logoUrl: 'https://images.app.goo.gl/k7Yc6Yb6ebeaB9HB8',
+        website: undefined,
+        contactEmail: undefined,
+        GSI1PK: 'ORG',
+        GSI1SK: 'ORG#JOLLIBEE',
+    },
+    {
+        PK: 'ORG#PIZZAHUT',
+        SK: 'ENTITY',
+        id: 'b58bfbd2-7055-4134-aa74-304ae42bf8a8',
+        name: 'Pizza Hut',
+        description: undefined,
+        createdBy: '81dfd46b-05ba-4cd0-96d8-7ea2cb0c2c70',
+        createdAt: '2025-04-01T17:26:48.302Z',
+        updatedAt: '2025-04-01T17:26:48.302Z',
+        type: 'ORGANIZATION',
+        isPublic: true,
+        logoUrl: 'https://images.app.goo.gl/k7Yc6Yb6ebeaB9HB8',
+        website: undefined,
+        contactEmail: undefined,
+        GSI1PK: 'ORG',
+        GSI1SK: 'ORG#PIZZAHUT',
+    },
+]

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -3,37 +3,29 @@
 import { Request, Response, NextFunction, Router } from 'express';
 import { EventService } from '../services/eventService';
 import { EventRequest, Event, EventUser } from '../models/Event';
-import { AppError } from '../middleware/errorHandler';
 import { UserRole } from '../models/User';
-import { OrgService } from '../services/orgService';
-import { UserOrganizationRelationship } from '../models/Organizations';
+import { checkOrgAdmin } from '../middleware/OrgMiddleware';
 
-const orgService = new OrgService();
 const eventService = new EventService();
 export const eventRouter = Router();
-
-eventRouter.post('/:id/events', async (req: Request, res: Response, next: NextFunction) => {
+/*
+  * Create an organization's event
+  * POST /:id/events
+  * */
+eventRouter.post('/:id/events', checkOrgAdmin, async (req: Request, res: Response, next: NextFunction) => {
     try {
         const orgName: string = req.params.id;
-        const user = res.locals.user as { id: string; email: string; role: UserRole };
-
-        if (!user) {
-            return next(new AppError('Unauthorized: Missing user information ', 403));
-        }
-
-        const isAdminAtOrg: UserOrganizationRelationship | null =
-            await orgService.findSpecificOrgByUser(orgName, user.id);
-        if (!isAdminAtOrg || isAdminAtOrg.role !== UserRole.ADMIN) {
-            return next(new AppError('Forbidden: You must be an org admin to create events.', 403));
-        }
+        const user = res.locals.user as { id: string; email: string; role: string };
 
         const eventRequest: EventRequest = {
             title: req.body.title,
             description: req.body.description,
             date: req.body.date,
         };
+
         const event: Event = await eventService.addEventToOrganization(orgName, eventRequest);
         const userEvent: EventUser = await eventService.addEventUser(user.id, event.id);
+
         return res.status(201).json({
             status: 'success',
             data: {
@@ -46,13 +38,10 @@ eventRouter.post('/:id/events', async (req: Request, res: Response, next: NextFu
     }
 });
 
-// public since they're user specific
-// eventRouter.get("/user/:id/events", async (req: Request, res: Response, next: NextFunction) => { })
-
-// Should have access to the token user, which gives me admin role
-// Non-Members should only see the public events
-// Members should be able to see all the events
-
+/*
+  * Get the organizations events 
+  * GET /:id/events
+  * */
 eventRouter.get('/:id/events', async (req: Request, res: Response, next: NextFunction) => {
     const orgID: string = req.params.id;
     const user = res.locals.user as {
@@ -74,43 +63,3 @@ eventRouter.get('/:id/events', async (req: Request, res: Response, next: NextFun
     }
 });
 
-// These should be protected via the user's role in org || Add middleware somewhere around here
-// Only admins should be able to edit the events information
-// Should have access to the token user, which gives me the admin role
-//
-// eventRouter.patch("/:id/events/:eid", async (req: Request, res: Response, next: NextFunction) => {
-//
-//   const orgId: string = req.params.id;
-//   const eventId: string = req.params.eid;
-//   const token = req.headers.authorization;
-//
-//   // Add event body validation
-//
-//   try {
-//     // What values am I updating
-//     const updateBody: EventUpdateRequest = req.body;
-//     const event: Event = await eventService.updateOrganizationEvent(orgId, eventId, updateBody);
-//   } catch (error) {
-//     next(error);
-//   }
-// })
-
-// This should create the attending event record
-// Users should be able to attend an event
-// Should have access to the token user, which gives me the member role
-//
-// eventRouter.post("/:id/events/:eid", async (req: Request, res: Response, next: NextFunction) => {
-//
-//   const orgId = req.params.id;
-//   const eventId = req.params.eid;
-//   const token = req.headers.authorization;
-//
-//   // Add event body validation
-//
-//   try {
-//     const { } = req.body;
-//
-//   } catch (error) {
-//     next(error);
-//   }
-// })

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -5,6 +5,7 @@ import { EventService } from '../services/eventService';
 import { EventRequest, Event, EventUser } from '../models/Event';
 import { UserRole } from '../models/User';
 import { checkOrgAdmin } from '../middleware/OrgMiddleware';
+import { validateUserID } from './orgController';
 
 const eventService = new EventService();
 export const eventRouter = Router();
@@ -12,7 +13,7 @@ export const eventRouter = Router();
   * Create an organization's event
   * POST /:id/events
   * */
-eventRouter.post('/:id/events', checkOrgAdmin, async (req: Request, res: Response, next: NextFunction) => {
+eventRouter.post('/:id/events', validateUserID, checkOrgAdmin, async (req: Request, res: Response, next: NextFunction) => {
     try {
         const orgName: string = req.params.id;
         const user = res.locals.user as { id: string; email: string; role: string };
@@ -42,13 +43,8 @@ eventRouter.post('/:id/events', checkOrgAdmin, async (req: Request, res: Respons
   * Get the organizations events 
   * GET /:id/events
   * */
-eventRouter.get('/:id/events', async (req: Request, res: Response, next: NextFunction) => {
+eventRouter.get('/:id/events', validateUserID, async (req: Request, res: Response, next: NextFunction) => {
     const orgID: string = req.params.id;
-    const user = res.locals.user as {
-        id: string;
-        email: string;
-        role: UserRole;
-    };
 
     try {
         const events: Event[] = await eventService.getAllOrganizationEvents(orgID);

--- a/src/controllers/guestController.ts
+++ b/src/controllers/guestController.ts
@@ -1,0 +1,70 @@
+import { Request, Response, Router, NextFunction } from 'express';
+import { OrgService } from '../services/orgService';
+import { AppError } from '../middleware/errorHandler';
+import { EventService } from '../services/eventService';
+import { Event } from '../models/Event';
+
+const orgService = new OrgService();
+const eventService = new EventService();
+
+export const guestRouter = Router();
+
+/*
+ * Should be able to view all the public organizations, and their public
+ * events.
+ *
+ * Limits the total organizations to 9 per request (via orgRepo);
+ * */
+guestRouter.get(`/`, async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lastEvaluatedKey = req.query.lastEvaluatedKey || undefined;
+
+        const { orgs, newLastEvaluatedKey } = await orgService.findAllPublicOrgs(
+            lastEvaluatedKey as Record<string, any>
+        );
+
+        if (!orgs || orgs.length === 0) {
+            throw new AppError(`No organizations found!`, 204);
+        }
+        return res.status(200).json({
+            message: `Here are all organizations!`,
+            data: {
+                organizations: orgs,
+            },
+            lastEvaluatedKey: newLastEvaluatedKey,
+        });
+    } catch (error) {
+        next(error);
+    }
+});
+
+/*
+ * Returning the public events from a specific organizations
+*
+ * Limits the total events to 9 per request (via eventRepo);
+ * */
+guestRouter.get(
+    '/organizations/:id/events',
+    async (req: Request, res: Response, next: NextFunction) => {
+        const orgID: string = req.params.id;
+
+        try {
+            const { events, newLastEvaluatedKey } =
+                await eventService.getAllPublicOrganizationEvents(orgID);
+
+            if (!events || events.length === 0) {
+                throw new AppError(`No public events found!`, 204);
+            }
+
+            return res.status(200).json({
+                status: 'success',
+                data: {
+                    events: events,
+                },
+                lastEvaluatedKey: newLastEvaluatedKey,
+            });
+        } catch (error) {
+            next(error);
+        }
+    }
+);

--- a/src/controllers/orgController.ts
+++ b/src/controllers/orgController.ts
@@ -13,7 +13,7 @@ const userService = new UserService();
 const orgService = new OrgService();
 export const orgRouter = Router();
 
-const validateUserID = async (req: Request, res: Response, next: NextFunction) => {
+export const validateUserID = async (req: Request, res: Response, next: NextFunction) => {
     const user = await userService.getUserByEmail(res.locals.user.email);
 
     if (!user) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,11 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import { authRouter } from './controllers/authController';
 import { orgRouter } from './controllers/orgController';
-import { authenticate } from './middleware/authMiddleware';
 import { errorHandler } from './middleware/errorHandler';
 import { loggerMethodMiddleware } from './middleware/loggerMiddleware';
 import { eventRouter } from './controllers/eventController';
+import { guestRouter } from './controllers/guestController';
+import { authenticate } from './middleware/authMiddleware';
 
 // Load environment variables
 dotenv.config();
@@ -23,8 +24,8 @@ app.use(loggerMethodMiddleware);
 
 // Routes
 app.use('/api/auth', authRouter);
-app.use(`/organization`, authenticate, eventRouter);
-app.use(`/organizations`, authenticate, orgRouter); // add authenticate middleware
+app.use(`/guests`, guestRouter);
+app.use(`/organizations`, authenticate, orgRouter, eventRouter); // add authenticate middleware
 
 // Default route
 app.get('/', (req, res) => {

--- a/src/middleware/OrgMiddleware.ts
+++ b/src/middleware/OrgMiddleware.ts
@@ -11,15 +11,11 @@ export const checkOrgAdmin = async (req: Request, res: Response, next: NextFunct
         const orgName: string = req.params.id;
         const user = res.locals.user as { id: string; email: string; role: UserRole };
 
-        if (!user) {
-            return next(new AppError('Only an Org Admin can perform this action. Please talk to your Admin for more information', 403));
-        }
-
         const isAdminOrg: UserOrganizationRelationship | null =
             await orgService.findSpecificOrgByUser(orgName, user.id);
 
         if (!isAdminOrg || isAdminOrg.role !== UserRole.ADMIN) {
-            return next(new AppError('Forbidden: You must be an org admin to create events.', 403));
+            return next(new AppError('Only an Org Admin can perform this action. Please talk to your Admin for more information', 403));
         }
 
         next();

--- a/src/middleware/OrgMiddleware.ts
+++ b/src/middleware/OrgMiddleware.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction } from 'express';
+import { OrgService } from '../services/orgService';
+import { AppError } from '../middleware/errorHandler';
+import { UserRole } from '../models/User';
+import { UserOrganizationRelationship } from '../models/Organizations';
+
+const orgService = new OrgService();
+
+export const checkOrgAdmin = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const orgName: string = req.params.id;
+        const user = res.locals.user as { id: string; email: string; role: UserRole };
+
+        if (!user) {
+            return next(new AppError('Unauthorized: Missing user information', 403));
+        }
+
+        const isAdminAtOrg: UserOrganizationRelationship | null =
+            await orgService.findSpecificOrgByUser(orgName, user.id);
+
+        if (!isAdminAtOrg || isAdminAtOrg.role !== UserRole.ADMIN) {
+            return next(new AppError('Forbidden: You must be an org admin to create events.', 403));
+        }
+
+        next();
+    } catch (error) {
+        next(error);
+    }
+};
+

--- a/src/middleware/OrgMiddleware.ts
+++ b/src/middleware/OrgMiddleware.ts
@@ -12,13 +12,13 @@ export const checkOrgAdmin = async (req: Request, res: Response, next: NextFunct
         const user = res.locals.user as { id: string; email: string; role: UserRole };
 
         if (!user) {
-            return next(new AppError('Unauthorized: Missing user information', 403));
+            return next(new AppError('Only an Org Admin can perform this action. Please talk to your Admin for more information', 403));
         }
 
-        const isAdminAtOrg: UserOrganizationRelationship | null =
+        const isAdminOrg: UserOrganizationRelationship | null =
             await orgService.findSpecificOrgByUser(orgName, user.id);
 
-        if (!isAdminAtOrg || isAdminAtOrg.role !== UserRole.ADMIN) {
+        if (!isAdminOrg || isAdminOrg.role !== UserRole.ADMIN) {
             return next(new AppError('Forbidden: You must be an org admin to create events.', 403));
         }
 

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export interface Event {
     PK: string; // EVENT#<ID>
-    SK: 'ENTITY';
+    SK: string;
 
     id: string;
     title: string;

--- a/src/models/Organizations.ts
+++ b/src/models/Organizations.ts
@@ -22,7 +22,7 @@ export interface Organization {
     contactEmail?: string;
 
     // GSI for finding organizations by creator
-    GSI1PK?: string; // NAME.substring(0,3).toUpperCase()
+    GSI1PK?: string; // ORG
     GSI1SK?: string; // ORG#NAME
 }
 
@@ -55,7 +55,7 @@ export const createOrganization = (
         logoUrl: request.logoUrl,
         website: request.website,
         contactEmail: request.contactEmail,
-        GSI1PK: request.name.substring(0, 3).toUpperCase(),
+        GSI1PK: 'ORG',
         GSI1SK: `ORG#${request.name.toUpperCase()}`,
     };
 };

--- a/src/repositories/eventRepository.ts
+++ b/src/repositories/eventRepository.ts
@@ -50,4 +50,137 @@ export class EventRepository {
         }
     }
 
+    /**
+     * Retrieves all events for a specific organization.
+     *
+     * @param orgID - The ID of the organization.
+     * @returns A list of events belonging to the organization.
+     * @throws {AppError} If the database operation fails.
+     */
+    async getOrgEvents(orgID: string): Promise<Event[]> {
+        try {
+            // Query events using the GSI2 index, filtering by organization ID.
+            const response = await dynamoDb.send(
+                new QueryCommand({
+                    TableName: TABLE_NAME,
+                    IndexName: 'GSI2PK-GSI2SK-INDEX',
+                    KeyConditionExpression: 'GSI2PK = :orgId AND begins_with(GSI2SK, :eventPrefix)',
+                    ExpressionAttributeValues: {
+                        ':orgId': `ORG#${orgID.toUpperCase()}`,
+                        ':eventPrefix': `EVENT#`,
+                    },
+                })
+            );
+
+            return response.Items as Event[];
+        } catch (error: any) {
+            throw new AppError(`Failed to retrieve events: ${error.message}`, 500);
+        }
+    }
+
+    /**
+     * Retrieves a specific event for an organization.
+     *
+     * @param orgID - The ID of the organization.
+     * @param eventID - The ID of the event.
+     * @returns The requested event.
+     * @throws {AppError} If the database operation fails.
+     */
+    async getOrgEvent(orgID: string, eventID: string): Promise<Event> {
+        try {
+            // Query for a specific event using the GSI2 index.
+            const response = await dynamoDb.send(
+                new QueryCommand({
+                    TableName: TABLE_NAME,
+                    IndexName: 'GSI2PK-GSI2SK-INDEX',
+                    KeyConditionExpression: 'GSI2PK = :orgID AND GSI2SK = :eventID',
+                    ExpressionAttributeValues: {
+                        ':orgID': `ORG#${orgID}`,
+                        ':eventID': `EVENT#${eventID}`,
+                    },
+                })
+            );
+
+            const items = response.Items as Event[];
+            return items[0]; // Return the first (and expected only) result.
+        } catch (error: any) {
+            throw new AppError(`Failed to retrieve event: ${error.message}`, 500);
+        }
+    }
+
+    /**
+     * Retrieves all events that a specific user is attending.
+     *
+     * @param userID - The ID of the user.
+     * @returns A list of events the user is attending.
+     * @throws {AppError} If the database operation fails.
+     */
+    async getUserEvents(userID: string): Promise<Event[]> {
+        try {
+            // Query user-related events using their primary key.
+            const response = await dynamoDb.send(
+                new QueryCommand({
+                    TableName: TABLE_NAME,
+                    KeyConditionExpression: 'PK = :userPK AND begins_with(SK, :skPrefix)',
+                    ExpressionAttributeValues: {
+                        ':userPK': `USER#${userID}`,
+                        ':skPrefix': 'EVENT#',
+                    },
+                })
+            );
+
+            return response.Items as Event[];
+        } catch (error: any) {
+            throw new AppError(`Failed to retrieve user events: ${error.message}`, 500);
+        }
+    }
+
+    /**
+     * Retrieves all events for a specific organization.
+     *
+     * @param orgID - The ID of the organization.
+     * @returns A list of events belonging to the organization.
+     * @throws {AppError} If the database operation fails.
+     */
+    async getPublicOrgEvents(
+        orgID: string
+    ): Promise<{ events: Event[]; newLastEvaluatedKey: Record<string, any> | null }> {
+        try {
+            let publicEvents: Event[] = [];
+            let lastEvaluatedKey: Record<string, any> | undefined = undefined;
+
+            // Keep querying until we have at least 9 public events or no more data
+            while (publicEvents.length < 9) {
+                const response: any = await dynamoDb.send(
+                    new QueryCommand({
+                        TableName: TABLE_NAME,
+                        IndexName: 'GSI2PK-GSI2SK-INDEX',
+                        KeyConditionExpression:
+                            'GSI2PK = :orgId AND begins_with(GSI2SK, :eventPrefix)',
+                        ExpressionAttributeValues: {
+                            ':orgId': `ORG#${orgID.toUpperCase()}`,
+                            ':eventPrefix': `EVENT#`,
+                        },
+                        Limit: 15, // Fetch more events to ensure enough public ones
+                        ExclusiveStartKey: lastEvaluatedKey || undefined,
+                    })
+                );
+
+                const fetchedEvents = response.Items as Event[];
+                publicEvents.push(...fetchedEvents.filter(event => event.isPublic));
+
+                // no more data to paginate
+                if (!response.LastEvaluatedKey) break;
+
+                lastEvaluatedKey = response.LastEvaluatedKey;
+            }
+
+            return {
+                events: publicEvents.slice(0, 9),
+                newLastEvaluatedKey: lastEvaluatedKey || null,
+            };
+        } catch (error: any) {
+            throw new AppError(`Failed to retrieve events: ${error.message}`, 500);
+        }
+    }
 }

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -64,4 +64,36 @@ export class EventService {
             throw new AppError(`Failed to create event: ${error.message}`, 500);
         }
     }
+
+    /**
+     * Retrieves all events for a given organization
+     * @param orgID - The organization ID
+     * @returns A list of events for the organization
+     */
+    async getAllOrganizationEvents(orgID: string): Promise<Event[]> {
+        try {
+            if (!orgID) throw new AppError('Invalid organization ID.', 400);
+
+            return await this.eventRepository.getOrgEvents(orgID);
+        } catch (error: any) {
+            throw new AppError(`Failed to retrieve organization events: ${error.message}`, 500);
+        }
+    }
+
+    /**
+     * Retrieves all public events for a given organization
+     * @param orgID - The organization ID
+     * @returns A list of events for the organization
+     */
+    async getAllPublicOrganizationEvents(
+        orgID: string
+    ): Promise<{ events: Event[]; newLastEvaluatedKey: Record<string, any> | null }> {
+        try {
+            if (!orgID) throw new AppError('Invalid organization ID.', 400);
+
+            return await this.eventRepository.getPublicOrgEvents(orgID);
+        } catch (error: any) {
+            throw new AppError(`Failed to retrieve organization events: ${error.message}`, 500);
+        }
+    }
 }

--- a/src/services/orgService.ts
+++ b/src/services/orgService.ts
@@ -183,4 +183,17 @@ export class OrgService {
             throw new AppError(`Updating Organization failed! ${(error as Error).message}`, 500);
         }
     }
+
+    async findAllPublicOrgs(
+        lastEvaluatedKey?: Record<string, any>
+    ): Promise<{ orgs: Organization[]; newLastEvaluatedKey: Record<string, any> | null }> {
+        try {
+            return await this.orgRepository.findAllPublicOrgs();
+        } catch (error) {
+            if (error instanceof AppError) {
+                throw error;
+            }
+            throw new AppError(`Updating Organization failed! ${(error as Error).message}`, 500);
+        }
+    }
 }


### PR DESCRIPTION
# Guest Router

### Get Public Organizations
**Endpoint:** `GET /guests`

**Description:** Retrieves a list of public organizations. The response is paginated with a maximum of 9 organizations per request.

**Request Parameters:**
- `lastEvaluatedKey` (optional, query parameter) – Used for pagination.

**Response:**
```json
{
  "message": "Here are all organizations!",
  "data": {
    "organizations": [
      {
        "id": "<org_id>",
        "name": "Organization Name",
        "description": "Public description of the organization"
      }
    ]
  },
  "lastEvaluatedKey": "<pagination_key>"
}
```

---

### Get Public Events of an Organization
**Endpoint:** `GET /guests/organizations/:id/events`

**Description:** Retrieves all public events for a specific organization.

**Path Parameters:**
- `id` (required) – Organization ID.

**Response:**
```json
{
  "status": "success",
  "data": {
    "events": [
      {
        "eventId": "<event_id>",
        "name": "Event Name",
        "date": "YYYY-MM-DD",
        "description": "Public event description"
      }
    ]
  },
  "lastEvaluatedKey": "<pagination_key>"
}
```