### PR TITLE
Add Request endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ Authorization: Bearer your-jwt-token
 |--------|----------|-------------|
 | POST | /api/auth/register | Register a new user |
 | POST | /api/auth/login | Login and get authentication token |
-| POST | /organizations | Create a new organization |
-| POST | /organizations/:id/events | Create a new organization event|
-| GET | /organizations/:id/events | Get organizations events|
-| GET | /guests/organizations | Get public organizations |
+| GET | /guests | Get public organizations |
 | GET | /guests/organizations/:id/events | Get public organizations events|
-| POST | /organization/:id/events | Create a new organization event|
 | GET | /organizations | Get all organizations for the authenticated user |
+| POST | /organizations | Create a new organization |
+| GET | /organizations/:id/events | Get organizations events|
+| POST | /organizations/:id/events | Create a new organization event|
+| POST | /organizations/:id | Apply to join an organization with events |
+
 
 ## 1. Authentication Endpoints
 
@@ -843,3 +844,92 @@ The system uses a single-table design in DynamoDB with the following structure:
 
 ---
 
+## Organization Membership 
+
+### Apply to an Organization
+Apply to join an organization. The organization must have at least one event.
+
+**Endpoint:** `POST /organizations/:id`
+
+#### Request Headers
+| Header | Value | Required | Description |
+|--------|-------|----------|-------------|
+| Authorization | Bearer [token] | Yes | JWT authentication token |
+
+#### Request Body
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| message | string | No | Optional message to the organization admins explaining why you want to join |
+```json
+{
+  "message": "I would like to join this organization",
+}
+```
+
+#### Response
+**Status Codes:**
+- 201: Created - Application submitted successfully
+- 400: Bad Request - Cannot apply to an organization without any events
+- 401: Unauthorized - Missing or invalid token
+- 404: Not Found - Organization not found
+- 409: Conflict - User has already applied or is already a member
+- 500: Internal Server Error - Server error
+
+**Success Response (201):**
+```json
+{
+  "status": "success",
+  "message": "Application submitted successfully",
+  "data": {
+    "request": {
+      "PK": "ORG#ORGNAME",
+      "SK": "REQUEST#userId",
+      "organizationName": "OrgName",
+      "userId": "userId",
+      "requestDate": "2023-04-04T12:34:56.789Z",
+      "message": "I would like to join this organization",
+      "status": "PENDING",
+      "type": "ORG_REQUEST"
+    }
+  }
+}
+```
+**Error Response (400):**
+```json
+{
+  "status": "error",
+  "message": "Cannot apply to an organization without any events"
+}
+```
+
+**Error Response (401):**
+```json
+{
+  "status": "error",
+  "message": "Authentication required"
+}
+```
+
+**Error Response (404):**
+```json
+{
+  "status": "error",
+  "message": "Organization not found"
+}
+```
+
+**Error Response (409):**
+```json
+{
+  "status": "error",
+  "message": "You are already a member of this organization"
+}
+```
+
+**Error Response (500):**
+```json
+{
+  "status": "error",
+  "message": "Internal server error"
+}
+```

--- a/__tests__/orgMembershipService.test.ts
+++ b/__tests__/orgMembershipService.test.ts
@@ -1,0 +1,139 @@
+// tests/services/orgMembershipService.test.ts
+
+import { OrgMembershipService } from '../src/services/orgMembershipService';
+import { OrgMembershipRepository } from '../src/repositories/orgMembershipRepository';
+import { EventService } from '../src/services/eventService';
+import { OrgService } from '../src/services/orgService';
+import { AppError } from '../src/middleware/errorHandler';
+import { OrganizationMembershipRequest } from '../src/models/Organizations';
+
+jest.mock('../src/repositories/orgMembershipRepository');
+jest.mock('../src/services/eventService');
+jest.mock('../src/services/orgService');
+
+describe('OrgMembershipService', () => {
+    let orgMembershipService: OrgMembershipService;
+    let mockOrgMembershipRepository: jest.Mocked<OrgMembershipRepository>;
+    let mockEventService: jest.Mocked<EventService>;
+    let mockOrgService: jest.Mocked<OrgService>;
+
+    const mockOrganizationName = 'testOrg';
+    const mockUserId = 'user123';
+    const mockMessage = 'Please let me join your organization';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockOrgMembershipRepository = new OrgMembershipRepository() as jest.Mocked<OrgMembershipRepository>;
+        mockEventService = new EventService() as jest.Mocked<EventService>;
+        mockOrgService = new OrgService() as jest.Mocked<OrgService>;
+
+        orgMembershipService = new OrgMembershipService(
+            mockOrgMembershipRepository,
+            mockEventService,
+            mockOrgService
+        );
+    });
+
+    describe('applyToOrganization', () => {
+        it('should successfully create a membership request ', async () => {
+            const mockOrg = { name: mockOrganizationName, isPublic: true } as any;
+            const mockEvents = [{ id: 'event1', title: 'Test Event' }] as any[];
+            const mockRequest = {
+                organizationName: mockOrganizationName,
+                userId: mockUserId,
+                message: mockMessage,
+                status: 'PENDING',
+                PK: `ORG#${mockOrganizationName.toUpperCase()}`,
+                SK: `REQUEST#${mockUserId}`
+            } as unknown as OrganizationMembershipRequest;
+
+            mockOrgService.findOrgByName.mockResolvedValue(mockOrg);
+            mockEventService.getAllOrganizationEvents.mockResolvedValue(mockEvents);
+            mockOrgMembershipRepository.createMembershipRequest.mockResolvedValue(mockRequest);
+
+            const result = await orgMembershipService.applyToOrganization(
+                mockOrganizationName, 
+                mockUserId, 
+                mockMessage
+            );
+
+            expect(mockOrgService.findOrgByName).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockEventService.getAllOrganizationEvents).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockOrgMembershipRepository.createMembershipRequest).toHaveBeenCalled();
+            expect(result).toEqual(mockRequest);
+        });
+
+        it('should throw an error if the organization does not exist', async () => {
+            mockOrgService.findOrgByName.mockResolvedValue(null);
+
+            await expect(
+                orgMembershipService.applyToOrganization(mockOrganizationName, mockUserId, mockMessage)
+            ).rejects.toThrow(new AppError('Organization not found', 404));
+
+            expect(mockOrgService.findOrgByName).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockEventService.getAllOrganizationEvents).not.toHaveBeenCalled();
+            expect(mockOrgMembershipRepository.createMembershipRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw an error if the organization has no events', async () => {
+            const mockOrg = { name: mockOrganizationName, isPublic: true } as any;
+            mockOrgService.findOrgByName.mockResolvedValue(mockOrg);
+            mockEventService.getAllOrganizationEvents.mockResolvedValue([]);
+
+            await expect(
+                orgMembershipService.applyToOrganization(mockOrganizationName, mockUserId, mockMessage)
+            ).rejects.toThrow(new AppError('Cannot apply to an organization without any events', 400));
+
+            expect(mockOrgService.findOrgByName).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockEventService.getAllOrganizationEvents).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockOrgMembershipRepository.createMembershipRequest).not.toHaveBeenCalled();
+        });
+
+        it('should throw errors from the repository', async () => {
+            // Arrange
+            const mockOrg = { name: mockOrganizationName, isPublic: true } as any;
+            const mockEvents = [{ id: 'event1', title: 'Test Event' }] as any[];
+            const repositoryError = new AppError('Database error', 500);
+
+            mockOrgService.findOrgByName.mockResolvedValue(mockOrg);
+            mockEventService.getAllOrganizationEvents.mockResolvedValue(mockEvents);
+            mockOrgMembershipRepository.createMembershipRequest.mockRejectedValue(repositoryError);
+
+            await expect(
+                orgMembershipService.applyToOrganization(mockOrganizationName, mockUserId, mockMessage)
+            ).rejects.toThrow(repositoryError);
+
+            expect(mockOrgService.findOrgByName).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockEventService.getAllOrganizationEvents).toHaveBeenCalledWith(mockOrganizationName);
+            expect(mockOrgMembershipRepository.createMembershipRequest).toHaveBeenCalled();
+        });
+
+        it('should create a request without a message when none is provided', async () => {
+            // Arrange
+            const mockOrg = { name: mockOrganizationName, isPublic: true } as any;
+            const mockEvents = [{ id: 'event1', title: 'Test Event' }] as any[];
+            const mockRequest = {
+                organizationName: mockOrganizationName,
+                userId: mockUserId,
+                message: undefined,
+                status: 'PENDING',
+                PK: `ORG#${mockOrganizationName.toUpperCase()}`,
+                SK: `REQUEST#${mockUserId}`
+            } as unknown as OrganizationMembershipRequest;
+
+            mockOrgService.findOrgByName.mockResolvedValue(mockOrg);
+            mockEventService.getAllOrganizationEvents.mockResolvedValue(mockEvents);
+            mockOrgService.findSpecificOrgByUser.mockResolvedValue(null);
+            mockOrgMembershipRepository.createMembershipRequest.mockResolvedValue(mockRequest);
+
+            const result = await orgMembershipService.applyToOrganization(
+                mockOrganizationName, 
+                mockUserId
+            );
+
+            expect(mockOrgMembershipRepository.createMembershipRequest).toHaveBeenCalled();
+            expect(result).toEqual(mockRequest);
+        });
+    });
+});

--- a/__tests__/utils/eventService-test-data.ts
+++ b/__tests__/utils/eventService-test-data.ts
@@ -2,8 +2,8 @@ import { title } from "process";
 import { Event, EventRequest } from "../../src/models/Event";
 
 
-export const ORGID = 'ORG#123';
-export const INVALID_ORGID = 'org##/invalid';
+export const ORGID = '123';
+export const INVALID_ORGID = 'invalid';
 
 export let validEventRequest: EventRequest= {
     title: 'New Event',

--- a/src/controllers/orgMemberShipController.ts
+++ b/src/controllers/orgMemberShipController.ts
@@ -1,0 +1,143 @@
+// src/controllers/orgMembershipController.ts
+
+import { Request, Response, Router, NextFunction } from 'express';
+import { OrgMembershipService } from '../services/orgMembershipService';
+import { validateUserID } from './orgController';
+// import { checkOrgAdmin } from "../middleware/OrgMiddleware";
+
+const orgMembershipService = new OrgMembershipService();
+export const orgMembershipRouter = Router();
+
+/**
+ * Apply to join an organization
+ * @route POST /organizations/:id/apply
+ */
+orgMembershipRouter.post(
+    '/:id',
+    validateUserID,
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const orgName: string = req.params.id;
+            const user = res.locals.user;
+            const { message } = req.body;
+
+            const request = await orgMembershipService.applyToOrganization(
+                orgName,
+                user.id,
+                message
+            );
+
+            return res.status(201).json({
+                status: 'success',
+                message: 'Application submitted successfully',
+                data: {
+                    request
+                }
+            });
+        } catch (error) {
+            next(error);
+        }
+    }
+);
+
+/**
+ * Get pending membership requests for an organization
+ * @route GET /organizations/:id/requests
+ */
+// orgMembershipRouter.get(
+//     '/:id/requests',
+//     validateUserID,
+//     checkOrgAdmin,
+//     async (req: Request, res: Response, next: NextFunction) => {
+//         try {
+//             const orgName: string = req.params.id;
+//             
+//             const requests = await orgMembershipService.getPendingRequests(orgName);
+//             
+//             // If there are requests, get user details for each
+//             const requestsWithUserDetails = await Promise.all(
+//                 requests.map(async (request) => {
+//                     const user = await orgMembershipService.getUserById(request.userId);
+//                     return {
+//                         ...request,
+//                         userDetails: user ? {
+//                             id: user.id,
+//                             email: user.email,
+//                             firstName: user.firstName,
+//                             lastName: user.lastName
+//                         } : null
+//                     };
+//                 })
+//             );
+//
+//             return res.status(200).json({
+//                 status: 'success',
+//                 data: {
+//                     requests: requestsWithUserDetails
+//                 }
+//             });
+//         } catch (error) {
+//             next(error);
+//         }
+//     }
+// );
+
+/**
+ * Approve a membership request
+ * @route POST /organizations/:id/requests/:userId/approve
+ */
+// orgMembershipRouter.post(
+//     '/:id/requests/:userId/approve',
+//     validateUserID,
+//     checkOrgAdmin,
+//     async (req: Request, res: Response, next: NextFunction) => {
+//         try {
+//             const orgName: string = req.params.id;
+//             const userId: string = req.params.userId;
+//
+//             const result = await orgMembershipService.approveRequest(
+//                 orgName,
+//                 userId
+//             );
+//
+//             return res.status(200).json({
+//                 status: 'success',
+//                 message: 'Membership request approved',
+//                 data: result
+//             });
+//         } catch (error) {
+//             next(error);
+//         }
+//     }
+// );
+
+/**
+ * Deny a membership request
+ * @route POST /organizations/:id/requests/:userId/deny
+ */
+// orgMembershipRouter.post(
+//     '/:id/requests/:userId/deny',
+//     validateUserID,
+//     checkOrgAdmin,
+//     async (req: Request, res: Response, next: NextFunction) => {
+//         try {
+//             const orgName: string = req.params.id;
+//             const userId: string = req.params.userId;
+//
+//             const result = await orgMembershipService.denyRequest(
+//                 orgName,
+//                 userId
+//             );
+//
+//             return res.status(200).json({
+//                 status: 'success',
+//                 message: 'Membership request denied',
+//                 data: {
+//                     request: result
+//                 }
+//             });
+//         } catch (error) {
+//             next(error);
+//         }
+//     }
+// );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { loggerMethodMiddleware } from './middleware/loggerMiddleware';
 import { eventRouter } from './controllers/eventController';
 import { guestRouter } from './controllers/guestController';
 import { authenticate } from './middleware/authMiddleware';
+import { orgMembershipRouter } from './controllers/orgMemberShipController';
 
 // Load environment variables
 dotenv.config();
@@ -25,7 +26,7 @@ app.use(loggerMethodMiddleware);
 // Routes
 app.use('/api/auth', authRouter);
 app.use(`/guests`, guestRouter);
-app.use(`/organizations`, authenticate, orgRouter, eventRouter); // add authenticate middleware
+app.use(`/organizations`, authenticate, orgRouter, eventRouter, orgMembershipRouter); // add authenticate middleware
 
 // Default route
 app.get('/', (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { loggerMethodMiddleware } from './middleware/loggerMiddleware';
 import { eventRouter } from './controllers/eventController';
 import { guestRouter } from './controllers/guestController';
 import { authenticate } from './middleware/authMiddleware';
-import { orgMembershipRouter } from './controllers/orgMemberShipController';
+import { orgMembershipRouter } from './controllers/orgMembershipController';
 
 // Load environment variables
 dotenv.config();

--- a/src/models/Event.ts
+++ b/src/models/Event.ts
@@ -52,7 +52,7 @@ export const createEvent = (orgID: string, eventRequest: EventRequest): Event =>
         date: date,
         createdAt: now,
         updatedAt: now,
-        GSI2PK: orgID,
+        GSI2PK: `ORG#${orgID.toUpperCase()}`,
         GSI2SK: eventId,
     };
 };

--- a/src/models/Organizations.ts
+++ b/src/models/Organizations.ts
@@ -144,6 +144,8 @@ export interface OrganizationMembershipRequest {
     message?: string;
     status: 'PENDING' | 'APPROVED' | 'DENIED';
     type: 'ORG_REQUEST';
+    GSI1PK: string; // REQUEST#<userId>
+    GSI1SK: string; // ORG#NAME
 }
 
 export const createOrganizationMembershipRequest = (
@@ -162,5 +164,7 @@ export const createOrganizationMembershipRequest = (
         message,
         status: 'PENDING',
         type: 'ORG_REQUEST',
+        GSI1PK: `REQUEST#${userId}` ,
+        GSI1SK: `ORG#${organizationName.toUpperCase()}`,
     };
 };

--- a/src/repositories/orgMembershipRepository.ts
+++ b/src/repositories/orgMembershipRepository.ts
@@ -1,0 +1,94 @@
+// Create a new repository file for handling organization membership requests
+// src/repositories/orgMembershipRepository.ts
+
+import { dynamoDb, TABLE_NAME } from '../config/db';
+import { OrganizationMembershipRequest } from '../models/Organizations';
+import { PutCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { AppError } from '../middleware/errorHandler';
+
+export class OrgMembershipRepository {
+    /**
+     * Creates a new membership request in the database
+     * @param request The membership request to create
+     * @returns The created membership request
+     */
+    async createMembershipRequest(request: OrganizationMembershipRequest): Promise<OrganizationMembershipRequest> {
+        try {
+            await dynamoDb.send(
+                new PutCommand({
+                    TableName: TABLE_NAME,
+                    Item: request,
+                    ConditionExpression: 'attribute_not_exists(PK) AND attribute_not_exists(SK)',
+                })
+            );
+            return request;
+        } catch (error: any) {
+            if (error.name === 'ConditionalCheckFailedException') {
+                throw new AppError('You have already submitted a request to join this organization', 409);
+            }
+            throw new AppError(`Failed to create membership request: ${error.message}`, 500);
+        }
+    }
+
+    /**
+     * Gets all pending membership requests for an organization
+     * @param organizationName The name of the organization
+     * @returns List of pending membership requests
+     */
+    // async getPendingRequestsByOrganization(organizationName: string): Promise<OrganizationMembershipRequest[]> {
+    //     try {
+    //         const result = await dynamoDb.send(
+    //             new QueryCommand({
+    //                 TableName: TABLE_NAME,
+    //                 KeyConditionExpression: 'PK = :orgKey AND begins_with(SK, :requestPrefix)',
+    //                 ExpressionAttributeValues: {
+    //                     ':orgKey': `ORG#${organizationName.toUpperCase()}`,
+    //                     ':requestPrefix': 'REQUEST#',
+    //                 }
+    //             })
+    //         );
+    //
+    //         return (result.Items || []) as OrganizationMembershipRequest[];
+    //     } catch (error: any) {
+    //         throw new AppError(`Failed to fetch membership requests: ${error.message}`, 500);
+    //     }
+    // }
+
+    /**
+     * Updates the status of a membership request
+     * @param organizationName The name of the organization
+     * @param userId The ID of the user whose request is being updated
+     * @param status The new status (APPROVED or DENIED)
+     * @returns The updated membership request
+     */
+    // async updateRequestStatus(
+    //     organizationName: string,
+    //     userId: string,
+    //     status: 'APPROVED' | 'DENIED'
+    // ): Promise<OrganizationMembershipRequest> {
+    //     try {
+    //         const result = await dynamoDb.send(
+    //             new UpdateCommand({
+    //                 TableName: TABLE_NAME,
+    //                 Key: {
+    //                     PK: `ORG#${organizationName.toUpperCase()}`,
+    //                     SK: `REQUEST#${userId}`,
+    //                 },
+    //                 UpdateExpression: 'SET #status = :status, updatedAt = :updatedAt',
+    //                 ExpressionAttributeNames: {
+    //                     '#status': 'status',
+    //                 },
+    //                 ExpressionAttributeValues: {
+    //                     ':status': status,
+    //                     ':updatedAt': new Date().toISOString(),
+    //                 },
+    //                 ReturnValues: 'ALL_NEW',
+    //             })
+    //         );
+    //
+    //         return result.Attributes as OrganizationMembershipRequest;
+    //     } catch (error: any) {
+    //         throw new AppError(`Failed to update membership request: ${error.message}`, 500);
+    //     }
+    // }
+}

--- a/src/services/orgMembershipService.ts
+++ b/src/services/orgMembershipService.ts
@@ -1,0 +1,141 @@
+// src/services/orgMembershipService.ts
+
+import { EventService } from './eventService';
+import { OrgService } from './orgService';
+import { UserService } from './userService';
+import { OrgMembershipRepository } from '../repositories/orgMembershipRepository';
+import { 
+    OrganizationMembershipRequest,
+    UserOrganizationRelationship,
+    createOrganizationMembershipRequest,
+    // UserOrganizationRelationship,
+    // addOrganizationAdmin
+} from '../models/Organizations';
+// import { UserRole } from '../models/User';
+import { AppError } from '../middleware/errorHandler';
+
+export class OrgMembershipService {
+    private orgMembershipRepository: OrgMembershipRepository;
+    private eventService: EventService;
+    private orgService: OrgService;
+    private userService: UserService;
+
+    constructor(
+        orgMembershipRepository: OrgMembershipRepository = new OrgMembershipRepository(),
+        eventService: EventService = new EventService(),
+        orgService: OrgService = new OrgService(),
+        userService: UserService = new UserService()
+    ) {
+        this.orgMembershipRepository = orgMembershipRepository;
+        this.eventService = eventService;
+        this.orgService = orgService;
+        this.userService = userService;
+    }
+
+    /**
+     * Submits a request to join an organization
+     * @param organizationName The name of the organization to join
+     * @param userId The ID of the user requesting to join
+     * @param message Optional message from the user
+     * @returns The created membership request
+     */
+    async applyToOrganization(
+        organizationName: string,
+        userId: string,
+        message?: string
+    ): Promise<OrganizationMembershipRequest> {
+        // Validate that organization exists
+        const organization = await this.orgService.findOrgByName(organizationName);
+        if (!organization) {
+            throw new AppError('Organization not found', 404);
+        }
+
+        // Check if organization has any events 
+        const events = await this.eventService.getAllOrganizationEvents(organizationName);
+        if (!events || events.length === 0) {
+            throw new AppError('Cannot apply to an organization without any events', 400);
+        }
+
+        // Create the membership request
+        const request = createOrganizationMembershipRequest(organizationName, userId, message);
+        
+        return await this.orgMembershipRepository.createMembershipRequest(request);
+    }
+
+    /**
+     * Get a user by ID - utility method
+     * @param userId The user ID to look up
+     * @returns The user or null if not found
+     */
+    async getUserById(userId: string) {
+        return this.userService.getUserById(userId);
+    } 
+    
+    /**
+     * Get all pending membership requests for an organization
+     * @param organizationName The name of the organization
+     * @returns List of pending membership requests
+     */
+    // async getPendingRequests(organizationName: string): Promise<OrganizationMembershipRequest[]> {
+    //     return await this.orgMembershipRepository.getPendingRequestsByOrganization(organizationName);
+    // }
+
+    /**
+     * Approve a membership request
+     * @param organizationName The name of the organization
+     * @param adminId The ID of the admin approving the request
+     * @param userId The ID of the user whose request is being approved
+     * @returns The updated request and the new user-org relationship
+     */
+    // async approveRequest(
+    //     organizationName: string,
+    //     userId: string
+    // ): Promise<{request: OrganizationMembershipRequest, membership: UserOrganizationRelationship}> {
+    //
+    //     // Check if organization has events
+    //     const events = await this.eventService.getAllOrganizationEvents(organizationName);
+    //     if (!events || events.length === 0) {
+    //         throw new AppError('Cannot approve new members for an organization without events', 400);
+    //     }
+    //
+    //     // Update request status to APPROVED
+    //     const updatedRequest = await this.orgMembershipRepository.updateRequestStatus(
+    //         organizationName,
+    //         userId,
+    //         'APPROVED'
+    //     );
+    //
+    //     // Create user-organization relationship with MEMBER role
+    //     const userOrgRelationship = {
+    //         ...addOrganizationAdmin(organizationName, userId),
+    //         role: UserRole.MEMBER // Override the role from ADMIN to MEMBER
+    //     };
+    //     
+    //     const membership = await this.orgService.createUserOrganizationRelationship(userOrgRelationship);
+    //
+    //     return {
+    //         request: updatedRequest,
+    //         membership
+    //     };
+    // }
+
+    /**
+     * Deny a membership request
+     * @param organizationName The name of the organization
+     * @param adminId The ID of the admin denying the request
+     * @param userId The ID of the user whose request is being denied
+     * @returns The updated request
+     */
+    // async denyRequest(
+    //     organizationName: string,
+    //     userId: string
+    // ): Promise<OrganizationMembershipRequest> {
+    //     // Update request status to DENIED
+    //     return await this.orgMembershipRepository.updateRequestStatus(
+    //         organizationName,
+    //         userId,
+    //         'DENIED'
+    //     );
+    // }
+
+}

--- a/src/services/orgService.ts
+++ b/src/services/orgService.ts
@@ -231,4 +231,25 @@ export class OrgService {
             throw new AppError(`Updating Organization failed! ${(error as Error).message}`, 500);
         }
     }
+
+    /**
+     * Creates a user-organization relationship
+     * @param userOrg The user-organization relationship to create
+     * @returns The created relationship
+     */
+    async createUserOrganizationRelationship(
+        userOrg: UserOrganizationRelationship
+    ): Promise<UserOrganizationRelationship | null> {
+        try {
+            return await this.orgRepository.createUserAdmin(userOrg);
+        } catch (error) {
+            if (error instanceof AppError) {
+                throw error;
+            }
+            throw new AppError(
+                `Failed to create user-organization relationship: ${(error as Error).message}`,
+                500
+            );
+        }
+    }
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -107,4 +107,20 @@ export class UserService {
             { expiresIn: '24h' }
         );
     }
+
+    /**
+     * Get a user by ID
+     * @param userId The ID of the user to retrieve
+     * @returns The user or null if not found
+     */
+    async getUserById(userId: string): Promise<User | null> {
+        try {
+            return await this.userRepository.getUserById(userId);
+        } catch (error) {
+            if (error instanceof AppError) {
+                throw error;
+            }
+            throw new AppError(`Failed to get user by ID: ${(error as Error).message}`, 500);
+        }
+    }
 }


### PR DESCRIPTION
Apply to Organization
- Created user functionality to apply for membership to organizations that have existing events
- must have at least one event before accepting applications

### New Files:
- `src/repositories/orgMembershipRepository.ts`
    createMembershipRequest() - Stores application in DynamoDB with duplicate prevention
- `src/services/orgMembershipService.ts`
     applyToOrganization() - Business logic with validations for organization existence, event presence, and membership status
- `src/controllers/orgMembershipController.ts`
     POST endpoint at `/:id/apply` - Handles user requests to join organizations

### Modified Files:
- `src/app.ts` - Added orgMembershipRouter to organization routes
- `src/index.ts` - Updated to use app.ts structure
