### PR TITLE
Scrum 3 leave an organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The system uses a single-table design in DynamoDB with the following structure:
 | GET | /organizations/:id/members | Get organization members |
 | PUT | /organizations/:id/members/:userID | Update organization member |
 | DELETE | /organizations/:id/members/:userID | Remove organization member |
+| DELETE | /organizations/:id/members/:userID/leave | leave an organization |
 
 ---
 

--- a/__tests__/orgServiceMembers.test.ts
+++ b/__tests__/orgServiceMembers.test.ts
@@ -1,0 +1,216 @@
+import { OrgService } from '../src/services/orgService';
+import { OrgRepository } from '../src/repositories/orgRepository';
+import { UserRole } from '../src/models/User';
+import { UserOrganizationRelationship } from '../src/models/Organizations';
+import { AppError } from '../src/middleware/errorHandler';
+
+// Mock the repository
+jest.mock('../src/repositories/orgRepository');
+
+describe('OrgService Member Tests', () => {
+    let orgService: OrgService;
+    let mockOrgRepository: jest.Mocked<OrgRepository>;
+
+    const orgName = 'testOrg';
+    const userId = 'user123';
+    const adminId = 'admin456';
+
+    const mockMember: UserOrganizationRelationship = {
+        PK: `USER#${userId}`,
+        SK: `ORG#${orgName.toUpperCase()}`,
+        userId: userId,
+        organizationName: orgName,
+        role: UserRole.MEMBER,
+        joinedAt: '2023-01-01T00:00:00.000Z',
+        type: 'USER_ORG',
+        GSI1PK: `ORG#${orgName.toUpperCase()}`,
+        GSI1SK: `USER#${userId}`,
+    };
+
+    const mockAdmin: UserOrganizationRelationship = {
+        PK: `USER#${adminId}`,
+        SK: `ORG#${orgName.toUpperCase()}`,
+        userId: adminId,
+        organizationName: orgName,
+        role: UserRole.ADMIN,
+        joinedAt: '2023-01-01T00:00:00.000Z',
+        type: 'USER_ORG',
+        GSI1PK: `ORG#${orgName.toUpperCase()}`,
+        GSI1SK: `USER#${adminId}`,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockOrgRepository = new OrgRepository() as jest.Mocked<OrgRepository>;
+        orgService = new OrgService(mockOrgRepository);
+    });
+
+    describe('getOrgMembers', () => {
+        it('should retrieve all organization members', async () => {
+            const mockMembers = [mockMember, mockAdmin];
+            mockOrgRepository.getOrgMembers.mockResolvedValue(mockMembers);
+
+            const result = await orgService.getOrgMembers(orgName);
+
+            expect(result).toEqual(mockMembers);
+            expect(mockOrgRepository.getOrgMembers).toHaveBeenCalledWith(orgName);
+        });
+
+        it('should throw an error when no members are found', async () => {
+            mockOrgRepository.getOrgMembers.mockResolvedValue([]);
+
+            await expect(orgService.getOrgMembers(orgName)).rejects.toThrow(
+                new AppError('No members found for this organization', 404)
+            );
+        });
+
+        it('should propagate repository errors', async () => {
+            const error = new Error('Database error');
+            mockOrgRepository.getOrgMembers.mockRejectedValue(error);
+
+            await expect(orgService.getOrgMembers(orgName)).rejects.toThrow(
+                'Failed to get organization members: Database error'
+            );
+        });
+    });
+
+    describe('removeMember', () => {
+        it('should remove a member successfully', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockMember);
+            mockOrgRepository.removeMember.mockResolvedValue(true);
+
+            const result = await orgService.removeMember(orgName, userId);
+
+            expect(result).toBe(true);
+            expect(mockOrgRepository.findSpecificOrgByUser).toHaveBeenCalledWith(orgName, userId);
+            expect(mockOrgRepository.removeMember).toHaveBeenCalledWith(orgName, userId);
+        });
+
+        it('should throw an error when member does not exist', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(null);
+
+            await expect(orgService.removeMember(orgName, userId)).rejects.toThrow(
+                new AppError('Member not found in this organization', 404)
+            );
+
+            expect(mockOrgRepository.removeMember).not.toHaveBeenCalled();
+        });
+
+        it('should propagate repository errors during member lookup', async () => {
+            const error = new Error('Database error');
+            mockOrgRepository.findSpecificOrgByUser.mockRejectedValue(error);
+
+            await expect(orgService.removeMember(orgName, userId)).rejects.toThrow(
+                'Failed to remove member: Database error'
+            );
+        });
+    });
+
+    describe('updateMemberRole', () => {
+        it('should update a member\'s role successfully', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockMember);
+            const updatedMember = { ...mockMember, role: UserRole.ADMIN };
+            mockOrgRepository.updateMemberRole.mockResolvedValue(updatedMember);
+
+            const result = await orgService.updateMemberRole(orgName, userId, UserRole.ADMIN);
+
+            expect(result).toEqual(updatedMember);
+            expect(mockOrgRepository.findSpecificOrgByUser).toHaveBeenCalledWith(orgName, userId);
+            expect(mockOrgRepository.updateMemberRole).toHaveBeenCalledWith(
+                orgName,
+                userId,
+                UserRole.ADMIN
+            );
+        });
+
+        it('should throw an error when member does not exist', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(null);
+
+            await expect(
+                orgService.updateMemberRole(orgName, userId, UserRole.ADMIN)
+            ).rejects.toThrow(new AppError('Member not found in this organization', 404));
+
+            expect(mockOrgRepository.updateMemberRole).not.toHaveBeenCalled();
+        });
+
+        it('should propagate repository errors during update', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockMember);
+            const error = new Error('Database error');
+            mockOrgRepository.updateMemberRole.mockRejectedValue(error);
+
+            await expect(
+                orgService.updateMemberRole(orgName, userId, UserRole.ADMIN)
+            ).rejects.toThrow('Failed to update member role: Database error');
+        });
+    });
+
+    describe('leaveOrganization', () => {
+        it('should allow a regular member to leave an organization', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockMember);
+            mockOrgRepository.removeMember.mockResolvedValue(true);
+
+            const result = await orgService.leaveOrganization(orgName, userId);
+
+            expect(result).toBe(true);
+            expect(mockOrgRepository.findSpecificOrgByUser).toHaveBeenCalledWith(orgName, userId);
+            expect(mockOrgRepository.removeMember).toHaveBeenCalledWith(orgName, userId);
+        });
+
+        it('should allow an admin to leave if other admins exist', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockAdmin);
+            mockOrgRepository.getOrgMembers.mockResolvedValue([mockAdmin, { ...mockMember, role: UserRole.ADMIN }]);
+            mockOrgRepository.removeMember.mockResolvedValue(true);
+
+            const result = await orgService.leaveOrganization(orgName, adminId);
+
+            expect(result).toBe(true);
+            expect(mockOrgRepository.findSpecificOrgByUser).toHaveBeenCalledWith(orgName, adminId);
+            expect(mockOrgRepository.getOrgMembers).toHaveBeenCalledWith(orgName);
+            expect(mockOrgRepository.removeMember).toHaveBeenCalledWith(orgName, adminId);
+        });
+
+        it('should not allow the last admin to leave', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockAdmin);
+            mockOrgRepository.getOrgMembers.mockResolvedValue([mockAdmin, mockMember]);
+
+            await expect(orgService.leaveOrganization(orgName, adminId)).rejects.toThrow(
+                new AppError('Cannot leave organization: You are the only admin. Please assign another admin first.', 400)
+            );
+
+            expect(mockOrgRepository.findSpecificOrgByUser).toHaveBeenCalledWith(orgName, adminId);
+            expect(mockOrgRepository.getOrgMembers).toHaveBeenCalledWith(orgName);
+            expect(mockOrgRepository.removeMember).not.toHaveBeenCalled();
+        });
+
+        it('should not allow a user to make another member leave', async () => {
+            const differentUser = { ...mockMember, userId: 'different-user-id' };
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(differentUser);
+
+            await expect(orgService.leaveOrganization(orgName, userId)).rejects.toThrow(
+                new AppError('You cannot make another member leave', 403)
+            );
+
+            expect(mockOrgRepository.removeMember).not.toHaveBeenCalled();
+        });
+
+        it('should throw an error when member does not exist', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(null);
+
+            await expect(orgService.leaveOrganization(orgName, userId)).rejects.toThrow(
+                new AppError('Member not found in this organization', 401)
+            );
+
+            expect(mockOrgRepository.removeMember).not.toHaveBeenCalled();
+        });
+
+        it('should propagate repository errors', async () => {
+            mockOrgRepository.findSpecificOrgByUser.mockResolvedValue(mockMember);
+            const error = new Error('Database error');
+            mockOrgRepository.removeMember.mockRejectedValue(error);
+
+            await expect(orgService.leaveOrganization(orgName, userId)).rejects.toThrow(
+                'Failed to leave organization: Database error'
+            );
+        });
+    });
+});

--- a/docs/OrganizationsMembers.md
+++ b/docs/OrganizationsMembers.md
@@ -223,3 +223,64 @@ This endpoint allows organization admins to remove a member from the organizatio
   "message": "Failed to remove member from organization"
 }
 ```
+### 7.4 Leave Organization
+
+`DELETE /organizations/:id/members/:userId/leave`
+
+This endpoint allows users to leave an organization they are a member of. Admins cannot leave if they are the last admin of the organization.
+
+#### Request Headers
+
+| Key | Value | Required |
+|-----|-------|----------|
+| Authorization | Bearer your-jwt-token | Yes |
+
+#### Response
+
+**200 OK**
+```json
+{
+  "status": "success",
+  "message": "Successfully left the organization"
+}
+```
+
+**400 Bad Request**
+```json
+{
+  "status": "error",
+  "message": "Cannot leave organization: You are the only admin. Please assign another admin first."
+}
+```
+
+**403 Forbidden**
+```json
+{
+  "status": "error",
+  "message": "You cannot make another member leave"
+}
+```
+
+**401 Unauthorized**
+```json
+{
+  "status": "error",
+  "message": "You are NOT part of this Organization"
+}
+```
+
+**404 Not Found**
+```json
+{
+  "status": "error",
+  "message": "Organization not found"
+}
+```
+
+**500 Server Error**
+```json
+{
+  "status": "error",
+  "message": "Failed to leave organization"
+}
+```

--- a/src/controllers/orgMemberController.ts
+++ b/src/controllers/orgMemberController.ts
@@ -121,3 +121,27 @@ orgMemberRouter.patch(
         }
     }
 );
+
+/**
+ * Remove a member from an organization
+ * @route DELETE /members/:userId/leave
+ */
+orgMemberRouter.delete(
+    '/:userId/leave',
+    async (req: Request, res: Response, next: NextFunction) => {
+        try {
+            const orgName: string = req.params.orgId;
+            const user = res.locals.user;
+
+            await orgService.leaveOrganization(orgName, user.id);
+
+            return res.status(200).json({
+                status: 'success',
+                message: 'Successfully left the organization',
+            });
+        } catch (error) {
+            next(error);
+        }
+    }
+);
+

--- a/src/middleware/OrgMiddleware.ts
+++ b/src/middleware/OrgMiddleware.ts
@@ -47,10 +47,10 @@ export const checkOrgAdmin = async (req: Request, res: Response, next: NextFunct
 
 export const checkOrgMember = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const orgName: string = req.params.orgId;
+        const orgName: string = req.params.orgId || req.params.id;
         const user = res.locals.user as { id: string; email: string; role: UserRole };
 
-        console.log(`Checking organization membership for org: "${orgName}" and user: ${user.id}`);
+        // console.log(`Checking organization membership for org: "${orgName}" and user: ${user.id}`);
 
         const userMemberOrg: UserOrganizationRelationship | null =
             await orgService.findSpecificOrgByUser(orgName, user.id);


### PR DESCRIPTION
DELETE /organizations/:id/members/:userId/leave that allows users to leave an organization
- Preventing the last admin from leaving an organization
- users can only make themselves leave