### PR TITLE
member shouldn't be able to re-request membership

### DIFF
--- a/__tests__/orgServiceMembers.test.ts
+++ b/__tests__/orgServiceMembers.test.ts
@@ -14,10 +14,12 @@ describe('OrgService Member Tests', () => {
     const orgName = 'testOrg';
     const userId = 'user123';
     const adminId = 'admin456';
+    const email= 'test@example.com';
 
     const mockMember: UserOrganizationRelationship = {
         PK: `USER#${userId}`,
         SK: `ORG#${orgName.toUpperCase()}`,
+        email,
         userId: userId,
         organizationName: orgName,
         role: UserRole.MEMBER,
@@ -30,6 +32,7 @@ describe('OrgService Member Tests', () => {
     const mockAdmin: UserOrganizationRelationship = {
         PK: `USER#${adminId}`,
         SK: `ORG#${orgName.toUpperCase()}`,
+        email,
         userId: adminId,
         organizationName: orgName,
         role: UserRole.ADMIN,

--- a/src/services/orgMembershipService.ts
+++ b/src/services/orgMembershipService.ts
@@ -48,6 +48,11 @@ export class OrgMembershipService {
             throw new AppError('Organization not found', 404);
         }
 
+        const member = await this.orgService.isMemberOfOrg(organizationName, userId);
+        if (member) {
+          throw new AppError('You are already a part of this organization', 400);
+        }
+
         const events = await this.eventService.getAllOrganizationEvents(organizationName);
         if (!events || events.length === 0) {
             throw new AppError('Cannot apply to an organization without any events', 400);

--- a/src/services/orgService.ts
+++ b/src/services/orgService.ts
@@ -388,4 +388,22 @@ export class OrgService {
             throw new AppError(`Failed to update member role: ${(error as Error).message}`, 500);
         }
     }
+
+    /**
+     * Check if a user is already a member of the organization
+     * @param orgName The name of the organization
+     * @param userId The ID of the user to check
+     * @returns true if the user is already a member of the org
+     */
+    async isMemberOfOrg(orgName: string, userId: string): Promise<Boolean> {
+      try {
+        return await this.orgRepository.findSpecificOrgByUser(orgName, userId) != null;
+      } catch (error) {
+          if (error instanceof AppError) {
+              throw error;
+          }
+          throw new AppError(`Failed to check if user is member of org: ${(error as Error).message}`, 500);
+      }
+
+    }
 }


### PR DESCRIPTION
Files updated: 
- `src/services/orgService.ts`
    - IsMemberOfOrg(orgName, userId): Boolean
- `src/services/orgMembershipService.ts`
    - Added check for adverse behavior

Added & Fixed broken tests